### PR TITLE
Workaround broken Types / Tokens

### DIFF
--- a/lib/cdktf-ec2.ts
+++ b/lib/cdktf-ec2.ts
@@ -1,5 +1,4 @@
 import { Construct } from 'constructs';
-import { Token } from 'cdktf';
 import { DataAwsAmi, DataAwsAvailabilityZones as AZ } from '../.gen/providers/aws'
 // import { Ec2Instance } from './.gen/modules/terraform-aws-modules/ec2-instance/aws';
 import { Vpc } from '../.gen/modules/terraform-aws-modules/vpc/aws';
@@ -15,8 +14,6 @@ export interface VpcBaseProps {
 }
 
 export class VpcProvider extends Construct{
-  readonly privateSubnets: string[]
-  readonly publicSubnets?: string[];
   readonly vpc: Vpc;
 
   static getOrCreate(scope: Construct) {
@@ -33,10 +30,26 @@ export class VpcProvider extends Construct{
       enableNatGateway: props.enableNatGateway ?? true,
       singleNatGateway: props.singleNatGateway ?? true,
     })
-    
-    this.publicSubnets = Token.asList(this.vpc.publicSubnetsOutput)
-    this.privateSubnets = Token.asList(this.vpc.privateSubnetsOutput)
+  }
 
+  public get privateSubnets(): string[] {
+    return this.vpc.privateSubnetsOutput as unknown as string[]
+  }
+
+  public get publicSubnets(): string[] {
+    return this.vpc.publicSubnetsOutput as unknown as string[]
+  }
+
+  public privateSubnet(index: number): string {
+    return this.elementFromList(this.privateSubnets, index)
+  }
+
+  public publicSubnet(index: number): string {
+    return this.elementFromList(this.publicSubnets, index)
+  }
+
+  private elementFromList(attribute: string[], index: number): string {
+    return `\${element("${attribute}", ${index})}`
   }
 }
 

--- a/main.ts
+++ b/main.ts
@@ -24,7 +24,7 @@ class Ec2Stack extends TerraformStack {
     const instance = new Instance(this, 'Instance', {
       ami: props.ami ?? amzn2.imageId,
       instanceType: props.instanceType ?? 't3.large',
-      subnetId: vpc.publicSubnets![0],
+      subnetId: vpc.publicSubnet(0)
       }
     )
 


### PR DESCRIPTION
This is a workaround for the lack of typed module outputs, and skips the usage of tokens (there's a related issue for that https://github.com/hashicorp/terraform-cdk/issues/256). 

Created three issues around this:

- https://github.com/hashicorp/terraform-cdk/issues/287
- https://github.com/hashicorp/terraform-cdk/issues/286
- https://github.com/hashicorp/terraform-cdk/issues/288

### Alternative 

I was playing around with another approach for setting up a VPC as CDK construct. Perhaps that's also useful to you:

```ts
import { Construct } from "constructs";
import { TerraformResource } from "cdktf";
import { Vpc, InternetGateway, Subnet } from "./gen/provider/aws";
import { AwsRegion } from "./aws-regions";
import { CIDRBlock } from "@eryldor/cidr";

export interface AwsVpcConfig {
  readonly region: AwsRegion;
  readonly cidrBlock: string;
}

export class AwsVpc extends Construct {
  public readonly publicSubnets: Subnet[];
  public readonly privateSubnets: Subnet[];
  public readonly waitFor: TerraformResource[] = [];

  constructor(scope: Construct, name: string, config: AwsVpcConfig) {
    super(scope, name);

    const cidr = CIDRBlock.fromString(config.cidrBlock);
    const [publicSubnetBlock, privateSubnetBlock] = cidr.split(2);
    const publicSubnets = publicSubnetBlock.split(3);
    const privateSubnets = privateSubnetBlock.split(3);

    const vpcMain = new Vpc(this, "main", {
      cidrBlock: config.cidrBlock,
      tags: {
        Name: name,
      },
    });

    new InternetGateway(this, "igw", {
      vpcId: vpcMain.id,
    });

    this.publicSubnets = config.region.zones.map(
      (zone, index) =>
        new Subnet(this, `public-${zone}`, {
          vpcId: vpcMain.id!,
          cidrBlock: publicSubnets[index].toString(),
          availabilityZone: zone,
          tags: {
            Name: `${name}-public-${zone}`,
          },
        })
    );

    this.privateSubnets = config.region.zones.map(
      (zone, index) =>
        new Subnet(this, `private-${zone}`, {
          vpcId: vpcMain.id!,
          cidrBlock: privateSubnets[index].toString(),
          availabilityZone: zone,
          tags: {
            Name: `${name}-public-${zone}`,
          },
        })
    );
  }
}
```